### PR TITLE
Logging matches to Prometheus

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="synapse-spamcheck-badlist",
-    version="0.2.1",
+    version="0.2.2",
     packages=find_packages(),
     description="A Synapse spam filter designed to block links and upload of content already known as bad. The typical use case is to plug this with a list of links and MD5s of child sexual abuse, as published by the IWF.",
     include_package_data=True,

--- a/synapse_spamcheck_badlist/bad_list_filter.py
+++ b/synapse_spamcheck_badlist/bad_list_filter.py
@@ -19,7 +19,7 @@ import time
 
 import ahocorasick
 from ahocorasick import Automaton
-from prometheus_client import Histogram
+from prometheus_client import Counter, Histogram
 from twisted.internet import defer, reactor
 from twisted.internet.task import LoopingCall
 from twisted.internet.threads import deferToThread
@@ -29,6 +29,14 @@ logger = logging.getLogger(__name__)
 link_check_performance = Histogram(
     "synapse_spamcheck_badlist_link_check_performance",
     "Performance of link checking, in seconds. This operation is in the critical path between a message being sent and that message being delivered to other members.",
+)
+badlist_md5_found = Counter(
+    "synapse_spamcheck_badlist_md5_found",
+    "Number of bad uploads found by md5 check",
+)
+badlist_link_found = Counter(
+    "synapse_spamcheck_badlist_link_found",
+    "Number of bad uploads found by link check",
 )
 
 
@@ -144,6 +152,7 @@ class BadListFilter(object):
             ]:
                 for _ in automaton.iter(text):
                     logger.info("Rejected bad link")
+                    badlist_link_found.inc()
                     return True
 
         # Not spam
@@ -164,6 +173,7 @@ class BadListFilter(object):
             hex_digest,
         ):
             logger.info("Rejected bad media file")
+            badlist_md5_found.inc()
             return True
         return False
 


### PR DESCRIPTION
Let's make it a bit easier to find out how many matches we actually encounter, without having to parse too many logs.

~~In a future version, we may wish to attach more data, e.g. the room id and the user id.~~

Once we have https://github.com/matrix-org/synapse/issues/9807, we should be able to always attach room id, user id.