### PR TITLE
Fix bug when handling events with non-string bodies

### DIFF
--- a/synapse_spamcheck_badlist/bad_list_filter.py
+++ b/synapse_spamcheck_badlist/bad_list_filter.py
@@ -147,9 +147,12 @@ class BadListFilter(object):
             #
             # We always lower-case the url, as the IWF database is lowercase.
             for text in [
-                content.get("body", ""),
-                content.get("formatted_body", ""),
+                content.get("body"),
+                content.get("formatted_body"),
             ]:
+                if not isinstance(text, str):
+                    continue
+
                 for _ in automaton.iter(text):
                     logger.info("Rejected bad link")
                     badlist_link_found.inc()


### PR DESCRIPTION
```
TypeError: string required
  File "synapse/handlers/federation.py", line 1211, in try_backfill
    dom, room_id, limit=100, extremities=extremities
  File "synapse/handlers/federation.py", line 927, in backfill
    dest, room_id, limit=limit, extremities=extremities
  File "synapse/federation/federation_client.py", line 236, in backfill
    dest, pdus, outlier=True, room_version=room_version
  File "synapse/federation/federation_client.py", line 401, in _check_sigs_and_hash_and_fetch
    await concurrently_execute(_execute, pdus, 10000)
  File "twisted/internet/defer.py", line 1445, in _inlineCallbacks
    result = current_context.run(g.send, result)
  File "synapse/util/async_helpers.py", line 187, in _concurrently_execute_inner
    await maybe_awaitable(func(value))
  File "synapse/federation/federation_client.py", line 395, in _execute
    room_version=room_version,
  File "synapse/federation/federation_client.py", line 432, in _check_sigs_and_hash_and_fetch_one
    res = await self._check_sigs_and_hash(room_version, pdu)
  File "synapse/federation/federation_base.py", line 89, in _check_sigs_and_hash
    result = await self.spam_checker.check_event_for_spam(pdu)
  File "synapse/events/spamcheck.py", line 242, in check_event_for_spam
    res = await callback(event)  # type: Union[bool, str]
  File "synapse_spamcheck_badlist/bad_list_filter.py", line 153, in check_event_for_spam
    for _ in automaton.iter(text):
```



https://sentry.matrix.org/sentry/synapse-matrixorg/issues/224125/?query=is%3Aunresolved