### PR TITLE
Fix logging context going missing during update of list of bad links

### DIFF
--- a/synapse_spamcheck_badlist/bad_list_filter.py
+++ b/synapse_spamcheck_badlist/bad_list_filter.py
@@ -21,8 +21,8 @@ from prometheus_client import Counter, Histogram
 from twisted.internet import defer, reactor
 from twisted.internet.threads import deferToThread
 
-from synapse.logging.context import make_deferred_yieldable
 from synapse.metrics.background_process_metrics import run_as_background_process
+from synapse.module_api import make_deferred_yieldable
 
 logger = logging.getLogger(__name__)
 

--- a/synapse_spamcheck_badlist/bad_list_filter.py
+++ b/synapse_spamcheck_badlist/bad_list_filter.py
@@ -21,6 +21,7 @@ from prometheus_client import Counter, Histogram
 from twisted.internet import defer, reactor
 from twisted.internet.threads import deferToThread
 
+from synapse.logging.context import make_deferred_yieldable
 from synapse.metrics.background_process_metrics import run_as_background_process
 
 logger = logging.getLogger(__name__)
@@ -122,7 +123,7 @@ class BadListFilter(object):
             new_link_automaton = Automaton(ahocorasick.STORE_LENGTH)
             for link in links:
                 new_link_automaton.add_word(link)
-            await deferToThread(new_link_automaton.make_automaton)
+            await make_deferred_yieldable(deferToThread(new_link_automaton.make_automaton))
             self._link_automaton = new_link_automaton
         except Exception as e:
             logger.exception("_update_links_automaton: could not update")


### PR DESCRIPTION
Add a missing `make_deferred_yieldable` to restore the logging context
when resuming from `await`.