### PR TITLE
Port CI from BuildKite to GHA

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,22 @@
+name: CI
+on:
+  push:
+    branches: main
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare the Docker image for Synapse `develop`
+        run: test/before_test.sh
+      - name: Setup services and launch tests
+        run: docker-compose up --build --abort-on-container-exit
+
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Prepare the Docker image for Synapse `develop`
-        run: test/before_test.sh
+#      When CI ran on BuildKite, we used to also run the following script to build a
+#      Synapse docker image from scratch.
+#      I leave it here for posterity and completeness.
+#      - name: Prepare the Docker image for Synapse `develop`
+#        run: test/before_test.sh
       - name: Setup services and launch tests
         run: docker-compose up --build --abort-on-container-exit
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # A Dockerfile used for running tests.
 # This Dockerfile should work for other plug-ins, too.
 
-FROM matrixdotorg/synapse:latest
+FROM matrixdotorg/synapse:develop
 
 # Install extension.
 WORKDIR /data

--- a/test/before_test.sh
+++ b/test/before_test.sh
@@ -4,4 +4,4 @@
 
 \rm -Rf synapse
 git clone https://github.com/matrix-org/synapse.git
-docker build -t matrixdotorg/synapse -f synapse/docker/Dockerfile synapse
+DOCKER_BUILDKIT=1 docker build -t matrixdotorg/synapse -f synapse/docker/Dockerfile synapse


### PR DESCRIPTION
Fixes #26.

To save time I stopped the script from building the docker image and pull it from dockerhub. Synapse's CI publishes each build to dockerhub; building from scratch here was broken when we made buildkit a requirement in https://github.com/matrix-org/synapse/pull/11691.