### PR TITLE
Import `run_as_background_process` from Module API

### DIFF
--- a/synapse_spamcheck_badlist/bad_list_filter.py
+++ b/synapse_spamcheck_badlist/bad_list_filter.py
@@ -21,7 +21,6 @@ from prometheus_client import Counter, Histogram
 from twisted.internet import defer, reactor
 from twisted.internet.threads import deferToThread
 
-from synapse.metrics.background_process_metrics import run_as_background_process
 from synapse.module_api import make_deferred_yieldable
 
 logger = logging.getLogger(__name__)
@@ -98,7 +97,7 @@ class BadListFilter(object):
         # a fallback in `_get_links_automaton()`.
         reactor.callWhenRunning(
             lambda: defer.ensureDeferred(
-                run_as_background_process(func=self._update_links_automaton, desc="Background initial pull list of bad links")
+                api.run_as_background_process(func=self._update_links_automaton, desc="Background initial pull list of bad links")
             )
         )
 


### PR DESCRIPTION
The internal API should not be used, and recently changed shape in https://github.com/element-hq/synapse/pull/18670.

Use the version on the module API instead.