### PR TITLE
Use run_as_background_process shim

### DIFF
--- a/synapse_spamcheck_badlist/bad_list_filter.py
+++ b/synapse_spamcheck_badlist/bad_list_filter.py
@@ -21,7 +21,7 @@ from prometheus_client import Counter, Histogram
 from twisted.internet import defer, reactor
 from twisted.internet.threads import deferToThread
 
-from synapse.module_api import make_deferred_yieldable
+from synapse.module_api import make_deferred_yieldable, run_as_background_process
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +97,7 @@ class BadListFilter(object):
         # a fallback in `_get_links_automaton()`.
         reactor.callWhenRunning(
             lambda: defer.ensureDeferred(
-                api.run_as_background_process(func=self._update_links_automaton, desc="Background initial pull list of bad links")
+                run_as_background_process(func=self._update_links_automaton, desc="Background initial pull list of bad links")
             )
         )
 


### PR DESCRIPTION
So that the code works on both old and new versions of Synapse.

#31 used the "correct", new way of calling `run_as_background_process`. But it was not compatible with older releases of Synapse. Due to an operational incident, we had to flip back and forth, and this module kept needing to be upgraded/downgraded.